### PR TITLE
small things

### DIFF
--- a/src/main/java/com/github/chainmailstudios/astromine/registry/AstromineEntityTypes.java
+++ b/src/main/java/com/github/chainmailstudios/astromine/registry/AstromineEntityTypes.java
@@ -32,9 +32,9 @@ public class AstromineEntityTypes {
 					.build());
 
 	public static final EntityType<RocketEntity> ROCKET = register(
-			"rocket", FabricEntityTypeBuilder.create(SpawnGroup.MONSTER, RocketEntity::new)
+			"rocket", FabricEntityTypeBuilder.create(SpawnGroup.MISC, RocketEntity::new)
 					.dimensions(EntityDimensions.changing(1.5f, 17f))
-					.trackable(128, 4)
+					.trackable(256, 4)
 					.build());
 
 	public static void initialize() {

--- a/src/main/resources/data/astromine/tags/entity_types/does_not_breathe.json
+++ b/src/main/resources/data/astromine/tags/entity_types/does_not_breathe.json
@@ -1,6 +1,7 @@
 {
 	"replace": false,
 	"values": [
-		"minecraft:iron_golem"
+		"minecraft:iron_golem",
+		"minecraft:armor_stand"
 	]
 }


### PR DESCRIPTION
armor stands are now in the `does_not_breathe` tag because apparently they're a `LivingEntity`
the rocket is now in the `MISC` spawn group because theyre not a bloody monster
oh yeah and rockets are now trackable from further away because its cool to watch a rocket from afar