### PR TITLE
Fix patchouli issues, update dependencies

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@ org.gradle.jvmargs = -Xmx4G
 
 # Fabric
 minecraft_version = 1.16.1
-yarn_mappings = 1.16.1+build.9
+yarn_mappings = 1.16.1+build.17
 loader_version = 0.8.8+build.202
 
 #Fabric api
@@ -17,9 +17,9 @@ version_meta = fabric-1.16.1
 
 # Dependency
 cardinal_components_version = 2.4.1
-spinnery_version = 3.0.47+fabric-1.16.x
+spinnery_version = 3.0.48+fabric-1.16.x
 shapes_version = 2.0.0+build.10
-patchouli_version = 1.16-37.17-FABRIC
+patchouli_version = 1.16-37.19-FABRIC
 lba_version=0.7.0
 
 # Conveniences

--- a/src/main/resources/data/astromine/patchouli_books/manual/book.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/book.json
@@ -3,7 +3,7 @@
 	"landing_text": "text.astromine.manual.landing",
 	"version": "1",
 	"model": "astromine:manual",
-	"creative_tab": "astromine:astromine",
+	"creative_tab": "astromine.astromine",
 	"book_texture": "patchouli:textures/gui/book_cyan.png",
 	"i18n": true,
 	"show_progress": false

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/categories/resources.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/categories/resources.json
@@ -1,6 +1,6 @@
 {
-	"name": "text.astromine.patchouli.warfare.title",
-	"description": "text.astromine.patchouli.warfare.description",
+	"name": "text.astromine.patchouli.resources.title",
+	"description": "text.astromine.patchouli.resources.description",
 	"icon": "astromine:metite_ingot",
 	"sortnum": 1
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/components/gears.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/components/gears.json
@@ -7,14 +7,14 @@
 		{
 			"type": "spotlight",
 			"item": "astromine:iron_gear",
-			"title": "text.astromine.astronautics.gears.page_one.title",
-			"text": "text.astromine.astronautics.gears.page_one.text"
+			"title": "text.astromine.components.gears.page_one.title",
+			"text": "text.astromine.components.gears.page_one.text"
 		},
 		{
 			"type": "crafting",
 			"recipe": "astromine:iron_gear_from_ingot",
-			"title": "text.astromine.astronautics.gears.page_two.title",
-			"text": "text.astromine.astronautics.gears.page_two.text"
+			"title": "text.astromine.components.gears.page_two.title",
+			"text": "text.astromine.components.gears.page_two.text"
 		}
 	]
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/components/plates.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/components/plates.json
@@ -7,14 +7,14 @@
 		{
 			"type": "spotlight",
 			"item": "astromine:iron_plates",
-			"title": "text.astromine.astronautics.plates.page_one.title",
-			"text": "text.astromine.astronautics.plates.page_one.text"
+			"title": "text.astromine.components.plates.page_one.title",
+			"text": "text.astromine.components.plates.page_one.text"
 		},
 		{
 			"type": "crafting",
 			"recipe": "astromine:iron_plates_from_ingot",
-			"title": "text.astromine.astronautics.plates.page_two.text",
-			"text": "text.astromine.astronautics.plates.page_two.text"
+			"title": "text.astromine.components.plates.page_two.text",
+			"text": "text.astromine.components.plates.page_two.text"
 		}
 	]
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/creative_buffer.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/creative_buffer.json
@@ -7,8 +7,8 @@
 		{
 			"type": "spotlight",
 			"item": "astromine:creative_buffer",
-			"title": "text.astromine.gadgets.creative_buffer.page_one.title",
-			"text": "text.astromine.gadgets.creative_buffer.page_one.text"
+			"title": "text.astromine.machinery.creative_buffer.page_one.title",
+			"text": "text.astromine.machinery.creative_buffer.page_one.text"
 		}
 	]
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/creative_capacitor.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/creative_capacitor.json
@@ -7,8 +7,8 @@
 		{
 			"type": "spotlight",
 			"item": "astromine:creative_capacitor",
-			"title": "text.astromine.gadgets.creative_capacitor.page_one.title",
-			"text": "text.astromine.gadgets.creative_capacitor.page_one.text."
+			"title": "text.astromine.machinery.creative_capacitor.page_one.title",
+			"text": "text.astromine.machinery.creative_capacitor.page_one.text."
 		}
 	]
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/creative_tank.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/creative_tank.json
@@ -7,8 +7,8 @@
 		{
 			"type": "spotlight",
 			"item": "astromine:creative_tank",
-			"title": "text.astromine.gadgets.creative_tank.page_one.title",
-			"text": "text.astromine.gadgets.creative_tank.page_one.title,"
+			"title": "text.astromine.machinery.creative_tank.page_one.title",
+			"text": "text.astromine.machinery.creative_tank.page_one.title,"
 		}
 	]
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/electric_smelter.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/electric_smelter.json
@@ -7,13 +7,13 @@
 		{
 			"type": "spotlight",
 			"item": "astromine:electric_smelter",
-			"title": "text.astromine.gadgets.electric_smelter.page_one.title",
-			"text": "text.astromine.gadgets.electric_smelter.page_one.text"
+			"title": "text.astromine.machinery.electric_smelter.page_one.title",
+			"text": "text.astromine.machinery.electric_smelter.page_one.text"
 		},
 		{
 			"type": "crafting",
 			"recipe": "astromine:electric_smelter",
-			"title": "text.astromine.gadgets.electric_smelter.page_two.title"
+			"title": "text.astromine.machinery.electric_smelter.page_two.title"
 		}
 	]
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/electrolyzer.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/machinery/electrolyzer.json
@@ -7,13 +7,13 @@
 		{
 			"type": "spotlight",
 			"item": "astromine:electrolyzer",
-			"title": "text.astromine.gadgets.electrolyzer.page_one.title",
-			"text": "text.astromine.gadgets.electrolyzer.page_one.text"
+			"title": "text.astromine.machinery.electrolyzer.page_one.title",
+			"text": "text.astromine.machinery.electrolyzer.page_one.text"
 		},
 		{
 			"type": "crafting",
 			"recipe": "astromine:electrolyzer",
-			"title": "text.astromine.gadgets.electrolyzer.page_two.title"
+			"title": "text.astromine.machinery.electrolyzer.page_two.title"
 		}
 	]
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/resources/stellum.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/resources/stellum.json
@@ -7,24 +7,24 @@
 		{
 			"type": "spotlight",
 			"item": "astromine:stellum_ingot",
-			"title": "text.astromine.resources.asterite.page_one.title",
-			"text": "text.astromine.resources.asterite.page_one.text"
+			"title": "text.astromine.resources.stellum.page_one.title",
+			"text": "text.astromine.resources.stellum.page_one.text"
 		},
 		{
 			"type": "smelting",
 			"recipe": "astromine:stellum_ingot_from_smelting_ore",
-			"title": "text.astromine.resources.asterite.page_two.title",
-			"text": "text.astromine.resources.asterite.page_two.text"
+			"title": "text.astromine.resources.stellum.page_two.title",
+			"text": "text.astromine.resources.stellum.page_two.text"
 		},
 		{
 			"type": "text",
-			"title": "text.astromine.resources.asterite.page_three.title",
-			"text": "text.astromine.resources.asterite.page_three.text"
+			"title": "text.astromine.resources.stellum.page_three.title",
+			"text": "text.astromine.resources.stellum.page_three.text"
 		},
 		{
 			"type": "text",
-			"title": "text.astromine.resources.asterite.page_four.title",
-			"text": "text.astromine.resources.asterite.page_four.text"
+			"title": "text.astromine.resources.stellum.page_four.title",
+			"text": "text.astromine.resources.stellum.page_four.text"
 		}
 	]
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/resources/univite.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/resources/univite.json
@@ -7,23 +7,23 @@
 		{
 			"type": "spotlight",
 			"item": "astromine:univite_ingot",
-			"title": "Univite",
-			"text": ""
+			"title": "text.astromine.resources.univite.page_one.title",
+			"text": "text.astromine.resources.univite.page_one.text"
 		},
 		{
 			"type": "text",
-			"title": "Obtaining Univite",
-			"text": ""
+			"title": "text.astromine.resources.univite.page_two.title",
+			"text": "text.astromine.resources.univite.page_two.text"
 		},
 		{
 			"type": "text",
-			"title": "Usages",
-			"text": ""
+			"title": "text.astromine.resources.univite.page_three.title",
+			"text": "text.astromine.resources.univite.page_two.text"
 		},
 		{
 			"type": "text",
-			"title": "Statistics",
-			"text": ""
+			"title": "text.astromine.resources.univite.page_four.title",
+			"text": "text.astromine.resources.univite.page_two.text"
 		}
 	]
 }

--- a/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/warfare/nuclear_warhead.json
+++ b/src/main/resources/data/astromine/patchouli_books/manual/en_us/entries/warfare/nuclear_warhead.json
@@ -13,7 +13,7 @@
 		{
 			"type": "crafting",
 			"recipe": "astromine:nuclear_warhead",
-			"title": "text.astromine.warfare.nuclear_warhead.page_two.text"
+			"title": "text.astromine.warfare.nuclear_warhead.page_two.title"
 		}
 	]
 }


### PR DESCRIPTION
Manual now shows up in creative tab
Fixed a bunch of text pointing to invalid or otherwise wrong lang keys
Updated dependencies:
Yarn - `1.16.1+build.9` -> `1.16.1+build.17`
Spinnery - `3.0.47+fabric-1.16.x` -> `3.0.48+fabric-1.16.x`
Patchouli - `1.16-37.17-FABRIC` -> `1.16-37.19-FABRIC`