### PR TITLE
fix log spam

### DIFF
--- a/src/main/java/com/github/chainmailstudios/astromine/client/render/block/HolographicBridgeBlockEntityRenderer.java
+++ b/src/main/java/com/github/chainmailstudios/astromine/client/render/block/HolographicBridgeBlockEntityRenderer.java
@@ -30,7 +30,7 @@ public class HolographicBridgeBlockEntityRenderer extends BlockEntityRenderer<Ho
 		BlockState b = entity.getWorld().getBlockState(entity.getPos());
 
 		if(!(b.getBlock() instanceof HolographicBridgeProjectorBlock))  {
-			AstromineCommon.LOGGER.warn("Holo Bridge Projector BE exists in spot where it shouldn't! "+entity.getPos());
+			AstromineCommon.LOGGER.debug("Holo Bridge Projector BE exists in spot where it shouldn't! "+entity.getPos());
 			return;
 		}
 


### PR DESCRIPTION
this makes the holo bridge warning print as debug instead of as warn, so it doesn't spam client logs.