### PR TITLE
Revert "Update to Loom 0.5 to use it's "shareCaches" feature, I heard…

### DIFF
--- a/astromine-core/build.gradle
+++ b/astromine-core/build.gradle
@@ -1,6 +1,6 @@
 archivesBaseName = "astromine-core"
 shouldGenerateData = true
 
-loom {
+minecraft {
     accessWidener = file("src/main/resources/astromine-core.accesswidener")
 }

--- a/astromine-foundations/build.gradle
+++ b/astromine-foundations/build.gradle
@@ -1,7 +1,7 @@
 archivesBaseName = "astromine-foundations"
 shouldGenerateData = true
 
-loom {
+minecraft {
     accessWidener = file("src/main/resources/astromine-foundations.accesswidener")
 }
 

--- a/astromine-technologies/build.gradle
+++ b/astromine-technologies/build.gradle
@@ -1,7 +1,7 @@
 archivesBaseName = "astromine-technologies"
 shouldGenerateData = true
 
-loom {
+minecraft {
     accessWidener = file("src/main/resources/astromine-technologies.accesswidener")
 }
 

--- a/astromine-transportations/build.gradle
+++ b/astromine-transportations/build.gradle
@@ -1,6 +1,6 @@
 archivesBaseName = "astromine-transportations"
 
-loom {
+minecraft {
     accessWidener = file("src/main/resources/astromine-transportations.accesswidener")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -3,14 +3,10 @@ import net.fabricmc.loom.task.RunClientTask
 plugins {
     id 'maven-publish'
     id 'com.diffplug.spotless' version '5.1.0' apply false
-    id 'fabric-loom' version '0.5-SNAPSHOT'
+    id 'fabric-loom' version '0.4-SNAPSHOT' apply false
 }
 
 apply from: 'dependencies.gradle'
-
-loom {
-    shareCaches = true
-}
 
 allprojects {
     apply plugin: 'maven-publish'
@@ -24,10 +20,6 @@ allprojects {
     ext {
         shouldGenerateData = false
         isRunningGenerateDataTask = false
-    }
-
-    loom {
-        shareCaches = true
     }
 
     spotless {
@@ -129,7 +121,6 @@ allprojects {
         mappings group: 'net.fabricmc', name: 'yarn', version: mappings_version, classifier: 'v2'
         modImplementation "net.fabricmc:fabric-loader:$loader_version"
         useAsApiOptionally "net.fabricmc.fabric-api:fabric-api:$api_version"
-        modImplementation "com.google.code.findbugs:jsr305:3.0.2"
 
         tap(rootProject.ext.setDefaultApis)
     }


### PR DESCRIPTION
… it is really unstable but yeet, it is already unstable before using this new feature."

This reverts commit bd0b9bde2d059f5dfccd3219eb2fe32e52fc154c.