### PR TITLE
Fix LBA crash

### DIFF
--- a/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/lba/LibBlockAttributesCompatibility.java
+++ b/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/lba/LibBlockAttributesCompatibility.java
@@ -66,13 +66,15 @@ public final class LibBlockAttributesCompatibility {
 		if (blockEntity != null) {
 			SidedComponentProvider sidedComponentProvider = SidedComponentProvider.fromBlockEntity(blockEntity);
 
-			@Nullable
-			Direction direction = list.getTargetSide();
+			if(sidedComponentProvider != null) {
+				@Nullable
+				Direction direction = list.getTargetSide();
 
-			FluidInventoryComponent component = sidedComponentProvider.getSidedComponent(direction, AstromineComponentTypes.FLUID_INVENTORY_COMPONENT);
+				FluidInventoryComponent component = sidedComponentProvider.getSidedComponent(direction, AstromineComponentTypes.FLUID_INVENTORY_COMPONENT);
 
-			if (component != null) {
-				list.offer(new LibBlockAttributesWrapper(component));
+				if (component != null) {
+					list.offer(new LibBlockAttributesWrapper(component));
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hello, this should fix a crash when some mod attempts to get an LBA fluid attribute from a block entity that is not from Astromine.