### PR TITLE
[bugfix] Add proper handling to FluixMixerBlockEntity.java

### DIFF
--- a/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/LiquidGeneratorBlock.java
+++ b/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/LiquidGeneratorBlock.java
@@ -24,23 +24,53 @@
 
 package com.github.chainmailstudios.astromine.technologies.common.block;
 
+import com.github.chainmailstudios.astromine.common.block.base.WrenchableHorizontalFacingTieredBlockWithEntity;
+import com.github.chainmailstudios.astromine.common.volume.fluid.FluidVolume;
+import com.github.chainmailstudios.astromine.common.volume.fraction.Fraction;
+import com.github.chainmailstudios.astromine.technologies.common.block.entity.LiquidGeneratorBlockEntity;
+import com.github.chainmailstudios.astromine.technologies.common.screenhandler.LiquidGeneratorScreenHandler;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntity;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.entity.player.PlayerInventory;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.BucketItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.Items;
 import net.minecraft.network.PacketByteBuf;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
-
-import com.github.chainmailstudios.astromine.common.block.base.WrenchableHorizontalFacingTieredBlockWithEntity;
-import com.github.chainmailstudios.astromine.technologies.common.block.entity.LiquidGeneratorBlockEntity;
-import com.github.chainmailstudios.astromine.technologies.common.screenhandler.LiquidGeneratorScreenHandler;
 
 public abstract class LiquidGeneratorBlock extends WrenchableHorizontalFacingTieredBlockWithEntity {
 	public LiquidGeneratorBlock(Settings settings) {
 		super(settings);
+	}
+
+	@Override
+	public ActionResult onUse(BlockState state, World world, BlockPos pos, PlayerEntity player, Hand hand, BlockHitResult hit) {
+		ItemStack stack = player.getStackInHand(hand);
+		Item item = stack.getItem();
+		if (item instanceof BucketItem && item != Items.BUCKET) {
+			BlockEntity blockEntity = world.getBlockEntity(pos);
+			if(blockEntity instanceof  LiquidGeneratorBlockEntity){
+				Fluid bucketFluid = ((BucketItem)item).fluid;
+				LiquidGeneratorBlockEntity generatorEntity = (LiquidGeneratorBlockEntity) blockEntity;
+				FluidVolume volume = generatorEntity.getFluidComponent().getVolume(0);
+				if(volume.canAccept(bucketFluid) && generatorEntity.getBurningRecipeFor(bucketFluid).isPresent()){
+					volume.setFluid(bucketFluid);
+					volume.add(Fraction.bucket());
+				}
+				player.setStackInHand(hand, new ItemStack(Items.BUCKET));
+				return ActionResult.SUCCESS;
+			}
+		}
+		return super.onUse(state, world, pos, player, hand, hit);
 	}
 
 	public abstract static class Base extends LiquidGeneratorBlock {

--- a/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/entity/FluidMixerBlockEntity.java
+++ b/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/entity/FluidMixerBlockEntity.java
@@ -29,7 +29,6 @@ import com.github.chainmailstudios.astromine.common.component.inventory.EnergyIn
 import com.github.chainmailstudios.astromine.common.component.inventory.FluidInventoryComponent;
 import com.github.chainmailstudios.astromine.common.component.inventory.SimpleEnergyInventoryComponent;
 import com.github.chainmailstudios.astromine.common.component.inventory.SimpleFluidInventoryComponent;
-import com.github.chainmailstudios.astromine.common.inventory.BaseInventory;
 import com.github.chainmailstudios.astromine.common.utilities.tier.MachineTier;
 import com.github.chainmailstudios.astromine.common.volume.energy.EnergyVolume;
 import com.github.chainmailstudios.astromine.common.volume.fluid.FluidVolume;
@@ -41,16 +40,13 @@ import com.github.chainmailstudios.astromine.technologies.common.block.entity.ma
 import com.github.chainmailstudios.astromine.technologies.common.block.entity.machine.SpeedProvider;
 import com.github.chainmailstudios.astromine.technologies.common.block.entity.machine.TierProvider;
 import com.github.chainmailstudios.astromine.technologies.common.recipe.FluidMixingRecipe;
-import com.github.chainmailstudios.astromine.technologies.common.recipe.LiquidGeneratingRecipe;
 import com.github.chainmailstudios.astromine.technologies.registry.AstromineTechnologiesBlockEntityTypes;
 import com.github.chainmailstudios.astromine.technologies.registry.AstromineTechnologiesBlocks;
-import com.github.chainmailstudios.astromine.technologies.registry.AstromineTechnologiesRecipeSerializers;
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.fluid.Fluid;
 import net.minecraft.nbt.CompoundTag;
-import net.minecraft.recipe.RecipeType;
-import net.minecraft.recipe.SmeltingRecipe;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.Optional;
@@ -72,48 +68,122 @@ public abstract class FluidMixerBlockEntity extends ComponentEnergyFluidBlockEnt
 		return new SimpleEnergyInventoryComponent(getEnergySize());
 	}
 
+	/**
+	 * Determine whether the recipe matches the provided fluids.
+	 * The existing fluid may be null, indicating that the inserting fluid is the only one present in the system
+	 *
+	 * @param r
+	 *        the recipe to match against
+	 * @param existing
+	 *        the fluid already present in the machine. may be null.
+	 * @param inserting
+	 *        the newly inserted fluid.
+	 * @return truthy if a recipe matching the provided fluids exists, falsy if no such recipe exists
+	 */
+	private static boolean isRecipeValid(FluidMixingRecipe r, Fluid existing, Fluid inserting) {
+		if (r.getFirstInputFluid() == inserting)
+			return true;
+		else if (r.getFirstInputFluid() != existing)
+			return false;
+
+		if (r.getSecondInputFluid() == inserting)
+			return true;
+		else if (r.getSecondInputFluid() != existing)
+			return false;
+		return false;
+	}
+
+	/**
+	 * Determine whether a recipe exists such that its input criteria are fulfilled by the provided fluids.
+	 * The existing fluid may be null, indicating that the inserting fluid is the only one present in the system
+	 *
+	 * @param existing
+	 *        the fluid already present in the machine. may be null.
+	 * @param inserting
+	 *        the newly inserted fluid.
+	 * @return truthy if a recipe matching the provided fluids exists, falsy if no such recipe exists
+	 */
+	private boolean hasMatchingRecipe(Fluid existing, Fluid inserting) {
+		return world.getRecipeManager().getAllOfType(FluidMixingRecipe.Type.INSTANCE).values().stream().filter(recipe -> recipe instanceof FluidMixingRecipe).anyMatch(recipe -> isRecipeValid((FluidMixingRecipe) recipe, existing, inserting));
+	}
+
+	/**
+	 * Find a slot already filled with the matching fluid
+	 *
+	 * @param target
+	 *        the fluid to find
+	 * @return -1 if no such slot exists, otherwise the 0-based index of the slot.
+	 */
+	private int findMergeableSlot(Fluid target) {
+		for (int i = 0; i < 2; i++) {
+			FluidVolume v = fluidComponent.getVolume(i);
+			if (v == null)
+				continue;
+			if (v.getFluid() == target) {
+				return i;
+			}
+		}
+		return -1;
+	}
+
 	@Override
 	protected FluidInventoryComponent createFluidComponent() {
-		FluidInventoryComponent fluidComponent = new SimpleFluidInventoryComponent(3)
-				.withInsertPredicate((direction, volume, slot) -> {
-					if (slot != 0 && slot != 1) {
+		FluidInventoryComponent fC = new SimpleFluidInventoryComponent(3).withInsertPredicate((direction, volume, slot) -> {
+			if (slot != 0 && slot != 1) {
+				return false;
+			}
+
+			Fluid insertedFluid = volume.getFluid();
+			int existingSlot = findMergeableSlot(insertedFluid);
+
+			// Allow merging into existing fluids, assuming a valid recipe
+			if (existingSlot == slot) {
+				return true;
+			}
+
+			// Don't allow overflow in the second input, if the first input is full
+			if (existingSlot != -1) {
+				return false;
+			}
+
+			Fluid otherFluid = null;
+			for (int i = 0; i < 2; i++) {
+				FluidVolume v = fluidComponent.getVolume(i);
+				if (v == null)
+					continue;
+				if (!v.isEmpty()) {
+					// No space left
+					if (otherFluid != null)
 						return false;
-					}
+					otherFluid = v.getFluid();
+				}
+			}
 
-					FluidInventoryComponent inventory = new SimpleFluidInventoryComponent(2);
+			return hasMatchingRecipe(otherFluid, insertedFluid);
+		}).withExtractPredicate((direction, volume, slot) -> {
+			return slot == 2;
+		}).withListener((inventory) -> {
+			shouldTry = true;
+			progress = 0;
+			limit = 100;
+			optionalRecipe = Optional.empty();
+		});
 
-					inventory.setVolume(0, volume);
-					inventory.setVolume(1, FluidHandler.of(this).getSecond());
-					inventory.setVolume(2, FluidHandler.of(this).getThird());
+		FluidHandler.of(fC).getFirst().setSize(getFluidSize());
+		FluidHandler.of(fC).getSecond().setSize(getFluidSize());
+		FluidHandler.of(fC).getThird().setSize(getFluidSize());
 
-					if (world != null) {
-						optionalRecipe = (Optional) world.getRecipeManager().getAllOfType(FluidMixingRecipe.Type.INSTANCE).values().stream().filter(recipe -> recipe instanceof FluidMixingRecipe).filter(recipe -> ((FluidMixingRecipe) recipe).matches(inventory)).findFirst();
-						return optionalRecipe.isPresent();
-					}
-
-					return false;
-				}).withExtractPredicate((direction, volume, slot) -> {
-					return slot == 2;
-				}).withListener((inventory) -> {
-					shouldTry = true;
-					progress = 0;
-					limit = 100;
-					optionalRecipe = Optional.empty();
-				});
-
-		FluidHandler.of(fluidComponent).getFirst().setSize(getFluidSize());
-		FluidHandler.of(fluidComponent).getSecond().setSize(getFluidSize());
-		FluidHandler.of(fluidComponent).getThird().setSize(getFluidSize());
-
-		return fluidComponent;
+		return fC;
 	}
 
 	@Override
 	public void tick() {
 		super.tick();
 
-		if (world == null) return;
-		if (world.isClient) return;
+		if (world == null)
+			return;
+		if (world.isClient)
+			return;
 
 		FluidHandler.ofOptional(this).ifPresent(fluids -> {
 			EnergyVolume energyVolume = getEnergyComponent().getVolume();

--- a/astromine-technologies/src/main/resources/astromine-technologies.accesswidener
+++ b/astromine-technologies/src/main/resources/astromine-technologies.accesswidener
@@ -10,3 +10,4 @@ accessible method net/minecraft/client/com.github.chainmailstudios.astromine.tec
 accessible field net/minecraft/block/EntityShapeContext heldItem Lnet/minecraft/item/Item;
 accessible method net/minecraft/block/TallPlantBlock method_30036 (Lnet/minecraft/world/World;Lnet/minecraft/util/math/BlockPos;Lnet/minecraft/block/BlockState;Lnet/minecraft/entity/player/PlayerEntity;)V
 accessible field net/minecraft/util/DyeColor color I
+accessible field net/minecraft/item/BucketItem fluid Lnet/minecraft/fluid/Fluid;


### PR DESCRIPTION
Fluids now merge into existing stacks.
Fluids are no matched against partial recipes if no fluid is present in the machine.