### PR TITLE
[bugfix] Fix FluidVerticalBarWidget not showing actual fluid type

### DIFF
--- a/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/widget/blade/FluidVerticalBarWidget.java
+++ b/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/widget/blade/FluidVerticalBarWidget.java
@@ -75,7 +75,8 @@ public class FluidVerticalBarWidget extends AbstractWidget {
 	@Environment(EnvType.CLIENT)
 	@Override
 	public List<Text> getTooltip() {
-		return Lists.newArrayList(FluidUtilities.rawFraction(progressFraction.get(), limitFraction.get(), new TranslatableText("text.astromine.fluid")), new TranslatableText("text.astromine.tooltip.fractional_value", progressFraction.get().toDecimalString(), limitFraction.get()
+		Identifier fluidId = getFluidVolume().getFluidId();
+		return Lists.newArrayList(FluidUtilities.rawFraction(progressFraction.get(), limitFraction.get(), new TranslatableText(String.format("block.%s.%s", fluidId.getNamespace(), fluidId.getPath()))), new TranslatableText("text.astromine.tooltip.fractional_value", progressFraction.get().toDecimalString(), limitFraction.get()
 			.toDecimalString()));
 	}
 


### PR DESCRIPTION
FluidVerticalBarWidget till now only showed the literal string "Fluid" in the tooltip. This pull request instead shows the translated fluid block name.