### PR TITLE
Add comparator support

### DIFF
--- a/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/block/base/BlockWithEntity.java
+++ b/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/block/base/BlockWithEntity.java
@@ -55,6 +55,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
+import com.github.chainmailstudios.astromine.common.block.redstone.ComparatorMode;
 import com.github.chainmailstudios.astromine.common.item.base.EnergyVolumeItem;
 import com.github.chainmailstudios.astromine.common.item.base.FluidVolumeItem;
 
@@ -169,5 +170,19 @@ public abstract class BlockWithEntity extends Block implements BlockEntityProvid
 
 	protected boolean saveTagToDroppedItem() {
 		return true;
+	}
+
+	protected ComparatorMode getComparatorMode() {
+		return ComparatorMode.ITEMS;
+	}
+
+	@Override
+	public boolean hasComparatorOutput(BlockState state) {
+		return getComparatorMode().hasOutput();
+	}
+
+	@Override
+	public int getComparatorOutput(BlockState state, World world, BlockPos pos) {
+		return getComparatorMode().getOutput(world.getBlockEntity(pos));
 	}
 }

--- a/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/block/redstone/ComparatorMode.java
+++ b/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/block/redstone/ComparatorMode.java
@@ -1,0 +1,54 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Chainmail Studios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.chainmailstudios.astromine.common.block.redstone;
+
+import net.minecraft.block.entity.BlockEntity;
+import net.minecraft.screen.ScreenHandler;
+import org.jetbrains.annotations.Nullable;
+
+@FunctionalInterface
+public interface ComparatorMode {
+    ComparatorMode NONE = new ComparatorMode() {
+        @Override
+        public int getOutput(@Nullable BlockEntity entity) {
+            return 0;
+        }
+
+        @Override
+        public boolean hasOutput() {
+            return false;
+        }
+    };
+
+    ComparatorMode ITEMS = ScreenHandler::calculateComparatorOutput;
+    ComparatorMode FLUIDS = ComparatorOutput::forFluids;
+    ComparatorMode ENERGY = ComparatorOutput::forEnergy;
+
+    int getOutput(@Nullable BlockEntity entity);
+
+    default boolean hasOutput() {
+        return true;
+    }
+}

--- a/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/block/redstone/ComparatorOutput.java
+++ b/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/block/redstone/ComparatorOutput.java
@@ -1,0 +1,85 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2020 Chainmail Studios
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package com.github.chainmailstudios.astromine.common.block.redstone;
+
+import com.github.chainmailstudios.astromine.common.component.inventory.FluidComponent;
+import com.github.chainmailstudios.astromine.common.volume.fluid.FluidVolume;
+import com.github.chainmailstudios.astromine.common.volume.fraction.Fraction;
+import net.minecraft.block.entity.BlockEntity;
+import org.jetbrains.annotations.Nullable;
+import team.reborn.energy.Energy;
+import team.reborn.energy.EnergyHandler;
+
+import java.util.Collection;
+import java.util.function.Function;
+
+public class ComparatorOutput {
+    public static int forEnergy(@Nullable BlockEntity entity) {
+        if (entity == null) {
+            return 0;
+        }
+
+        EnergyHandler handler = Energy.of(entity);
+
+        if (handler.getEnergy() <= 0.0001) {
+            return 0;
+        }
+
+        return 1 + (int) (handler.getEnergy() / handler.getMaxStored() * 14.0);
+    }
+
+    public static int forFluids(@Nullable BlockEntity entity) {
+        if (entity == null) {
+            return 0;
+        }
+
+        FluidComponent fluidComponent = FluidComponent.get(entity);
+
+        if (fluidComponent == null) {
+            return 0;
+        }
+
+        Collection<FluidVolume> contents = fluidComponent.getContents().values();
+        Fraction amounts = sumBy(contents, FluidVolume::getAmount);
+
+        if (amounts.getNumerator() == 0) {
+            return 0;
+        }
+
+        Fraction sizes = sumBy(contents, FluidVolume::getSize);
+        Fraction ratio = amounts.divide(sizes);
+        return 1 + (int) (ratio.floatValue() * 14.0f);
+    }
+
+    private static <T> Fraction sumBy(Collection<T> ts, Function<? super T, Fraction> extractor) {
+        Fraction result = Fraction.empty();
+
+        for (T t : ts) {
+            result = result.add(extractor.apply(t));
+        }
+
+        return result;
+    }
+}

--- a/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/CapacitorBlock.java
+++ b/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/CapacitorBlock.java
@@ -35,6 +35,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import com.github.chainmailstudios.astromine.common.block.base.WrenchableHorizontalFacingTieredBlockWithEntity;
+import com.github.chainmailstudios.astromine.common.block.redstone.ComparatorMode;
 import com.github.chainmailstudios.astromine.technologies.common.block.entity.CapacitorBlockEntity;
 import com.github.chainmailstudios.astromine.technologies.common.screenhandler.CapacitorScreenHandler;
 
@@ -61,6 +62,11 @@ public abstract class CapacitorBlock extends WrenchableHorizontalFacingTieredBlo
 		@Override
 		public void populateScreenHandlerBuffer(BlockState state, World world, BlockPos pos, ServerPlayerEntity player, PacketByteBuf buffer) {
 			buffer.writeBlockPos(pos);
+		}
+
+		@Override
+		protected ComparatorMode getComparatorMode() {
+			return ComparatorMode.ENERGY;
 		}
 	}
 

--- a/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/FluidExtractorBlock.java
+++ b/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/FluidExtractorBlock.java
@@ -35,6 +35,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import com.github.chainmailstudios.astromine.common.block.base.WrenchableHorizontalFacingBlockWithEntity;
+import com.github.chainmailstudios.astromine.common.block.redstone.ComparatorMode;
 import com.github.chainmailstudios.astromine.technologies.common.block.entity.FluidExtractorBlockEntity;
 import com.github.chainmailstudios.astromine.technologies.common.screenhandler.FluidExtractorScreenHandler;
 
@@ -61,5 +62,10 @@ public class FluidExtractorBlock extends WrenchableHorizontalFacingBlockWithEnti
 	@Override
 	public void populateScreenHandlerBuffer(BlockState state, World world, BlockPos pos, ServerPlayerEntity player, PacketByteBuf buffer) {
 		buffer.writeBlockPos(pos);
+	}
+
+	@Override
+	protected ComparatorMode getComparatorMode() {
+		return ComparatorMode.FLUIDS;
 	}
 }

--- a/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/FluidInserterBlock.java
+++ b/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/FluidInserterBlock.java
@@ -35,6 +35,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import com.github.chainmailstudios.astromine.common.block.base.WrenchableHorizontalFacingBlockWithEntity;
+import com.github.chainmailstudios.astromine.common.block.redstone.ComparatorMode;
 import com.github.chainmailstudios.astromine.technologies.common.block.entity.FluidInserterBlockEntity;
 import com.github.chainmailstudios.astromine.technologies.common.screenhandler.FluidInserterScreenHandler;
 
@@ -61,5 +62,10 @@ public class FluidInserterBlock extends WrenchableHorizontalFacingBlockWithEntit
 	@Override
 	public void populateScreenHandlerBuffer(BlockState state, World world, BlockPos pos, ServerPlayerEntity player, PacketByteBuf buffer) {
 		buffer.writeBlockPos(pos);
+	}
+
+	@Override
+	protected ComparatorMode getComparatorMode() {
+		return ComparatorMode.FLUIDS;
 	}
 }

--- a/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/LiquidGeneratorBlock.java
+++ b/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/LiquidGeneratorBlock.java
@@ -35,6 +35,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import com.github.chainmailstudios.astromine.common.block.base.WrenchableHorizontalFacingTieredBlockWithEntity;
+import com.github.chainmailstudios.astromine.common.block.redstone.ComparatorMode;
 import com.github.chainmailstudios.astromine.technologies.common.block.entity.LiquidGeneratorBlockEntity;
 import com.github.chainmailstudios.astromine.technologies.common.screenhandler.LiquidGeneratorScreenHandler;
 
@@ -61,6 +62,11 @@ public abstract class LiquidGeneratorBlock extends WrenchableHorizontalFacingTie
 		@Override
 		public void populateScreenHandlerBuffer(BlockState state, World world, BlockPos pos, ServerPlayerEntity player, PacketByteBuf buffer) {
 			buffer.writeBlockPos(pos);
+		}
+
+		@Override
+		protected ComparatorMode getComparatorMode() {
+			return ComparatorMode.ENERGY;
 		}
 	}
 

--- a/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/SolidGeneratorBlock.java
+++ b/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/SolidGeneratorBlock.java
@@ -35,6 +35,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import com.github.chainmailstudios.astromine.common.block.base.WrenchableHorizontalFacingTieredBlockWithEntity;
+import com.github.chainmailstudios.astromine.common.block.redstone.ComparatorMode;
 import com.github.chainmailstudios.astromine.technologies.common.block.entity.SolidGeneratorBlockEntity;
 import com.github.chainmailstudios.astromine.technologies.common.screenhandler.SolidGeneratorScreenHandler;
 
@@ -61,6 +62,11 @@ public abstract class SolidGeneratorBlock extends WrenchableHorizontalFacingTier
 		@Override
 		public void populateScreenHandlerBuffer(BlockState state, World world, BlockPos pos, ServerPlayerEntity player, PacketByteBuf buffer) {
 			buffer.writeBlockPos(pos);
+		}
+
+		@Override
+		protected ComparatorMode getComparatorMode() {
+			return ComparatorMode.ENERGY;
 		}
 	}
 

--- a/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/TankBlock.java
+++ b/astromine-technologies/src/main/java/com/github/chainmailstudios/astromine/technologies/common/block/TankBlock.java
@@ -35,6 +35,7 @@ import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
 
 import com.github.chainmailstudios.astromine.common.block.base.WrenchableHorizontalFacingTieredBlockWithEntity;
+import com.github.chainmailstudios.astromine.common.block.redstone.ComparatorMode;
 import com.github.chainmailstudios.astromine.technologies.common.block.entity.TankBlockEntity;
 import com.github.chainmailstudios.astromine.technologies.common.screenhandler.TankScreenHandler;
 
@@ -61,6 +62,11 @@ public abstract class TankBlock extends WrenchableHorizontalFacingTieredBlockWit
 		@Override
 		public void populateScreenHandlerBuffer(BlockState state, World world, BlockPos pos, ServerPlayerEntity player, PacketByteBuf buffer) {
 			buffer.writeBlockPos(pos);
+		}
+
+		@Override
+		protected ComparatorMode getComparatorMode() {
+			return ComparatorMode.FLUIDS;
 		}
 	}
 


### PR DESCRIPTION
Adds comparator support for all blocks extending Astromine's `BlockWithEntity`. The comparator output calculation is done with a `ComparatorMode` interface that is provided by `BlockWithEntity.getComparatorMode`.

Comparator modes:

- Default: checking the item level (same behaviour as in vanilla)
- Tanks and fluid inserters/extractors: checking the fluid level
- Generators and capacitors: checking the energy level

This *should* work, but I haven't tested items yet. The energy comparator output is a bit broken, though. None of the Astromine block entities seem to call `markDirty` when they update their state, so the comparator outputs don't get updated either.