### PR TITLE
Fix the gravity multiplier attribute being registered before mod initialization

### DIFF
--- a/astromine-core/src/main/java/com/github/chainmailstudios/astromine/AstromineCommon.java
+++ b/astromine-core/src/main/java/com/github/chainmailstudios/astromine/AstromineCommon.java
@@ -79,6 +79,7 @@ public class AstromineCommon implements ModInitializer {
 		AstromineNetworkMembers.initialize();
 		AstromineCriteria.initialize();
 		AstromineFluidEffects.initialize();
+		AstromineAttributes.initialize();
 
 		if (FabricLoader.getInstance().isModLoaded("libblockattributes_fluids")) {
 			try {

--- a/astromine-core/src/main/java/com/github/chainmailstudios/astromine/registry/AstromineAttributes.java
+++ b/astromine-core/src/main/java/com/github/chainmailstudios/astromine/registry/AstromineAttributes.java
@@ -31,8 +31,9 @@ import net.minecraft.util.registry.Registry;
 import com.github.chainmailstudios.astromine.AstromineCommon;
 
 public class AstromineAttributes {
-	public static final EntityAttribute GRAVITY_MULTIPLIER = Registry.register(Registry.ATTRIBUTE, AstromineCommon.identifier("gravity_multiplier"), new ClampedEntityAttribute("attribute.name.generic.astromine.gravity_multiplier", 1d, -100d, 100d));
+	public static final EntityAttribute GRAVITY_MULTIPLIER = new ClampedEntityAttribute("attribute.name.generic.astromine.gravity_multiplier", 1d, -100d, 100d);
 
-	public static void initialize() {}
-
+	public static void initialize() {
+		Registry.register(Registry.ATTRIBUTE, AstromineCommon.identifier("gravity_multiplier"), GRAVITY_MULTIPLIER);
+	}
 }


### PR DESCRIPTION
This pull request makes the gravity multiplier attribute get registered after mod initialization. This fixes the item group issue described in FabricMC/fabric#1132 when both Astromine and Cinderscapes are loaded.