### PR TITLE
Define equals for FluidComponent, fixes #338

### DIFF
--- a/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/component/inventory/SimpleFluidComponent.java
+++ b/astromine-core/src/main/java/com/github/chainmailstudios/astromine/common/component/inventory/SimpleFluidComponent.java
@@ -33,7 +33,7 @@ import org.jetbrains.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BooleanSupplier;
+import java.util.Objects;
 
 public class SimpleFluidComponent implements FluidComponent {
 	private final Int2ObjectOpenHashMap<FluidVolume> contents = new Int2ObjectOpenHashMap<>();
@@ -103,5 +103,18 @@ public class SimpleFluidComponent implements FluidComponent {
 	@Override
 	public int getSize() {
 		return size;
+	}
+
+	@Override
+	public boolean equals(Object o) {	// used by CCA to tell if two stacks are equal
+		if (this == o) return true;
+		if (!(o instanceof SimpleFluidComponent)) return false;
+		SimpleFluidComponent entries = (SimpleFluidComponent) o;
+		return Objects.equals(contents, entries.contents);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(contents);
 	}
 }


### PR DESCRIPTION
As noted in the [wiki](https://github.com/OnyxStudios/Cardinal-Components-API/wiki/Cardinal-Components-Item), Cardinal Components API redefines ItemStack equality methods to check component equality as well. Forgetting to redefine `equals` on an item component can thus lead to some issues, as noted in #338.

This PR adds a simple `equals` implementation for `SimpleFluidComponent` using the content.